### PR TITLE
Streamlitの非推奨パラメータを修正

### DIFF
--- a/hairstyle_analyzer/ui/components/image_preview.py
+++ b/hairstyle_analyzer/ui/components/image_preview.py
@@ -80,7 +80,7 @@ class ImagePreviewComponent:
                     resized_image = pil_image.resize(new_size, Image.LANCZOS)
                     
                     # 画像を表示
-                    st.image(resized_image, caption=caption, use_column_width=True)
+                    st.image(resized_image, caption=caption, use_container_width=True)
                     
                     # 選択ボタン
                     if on_select:
@@ -119,7 +119,7 @@ class ImagePreviewComponent:
                     pil_image = pil_image.resize(new_size, Image.LANCZOS)
             
             # 画像を表示
-            st.image(pil_image, caption=caption, use_column_width=use_full_width)
+            st.image(pil_image, caption=caption, use_container_width=use_full_width)
         else:
             st.error("画像を表示できません")
     
@@ -188,7 +188,7 @@ class ImagePreviewComponent:
         if 0 <= selected_idx < len(images):
             selected_image = self._get_pil_image(images[selected_idx])
             if selected_image:
-                st.image(selected_image, caption=captions[selected_idx], use_column_width=True)
+                st.image(selected_image, caption=captions[selected_idx], use_container_width=True)
             else:
                 st.error("選択された画像を表示できません")
         
@@ -236,7 +236,7 @@ class ImagePreviewComponent:
                         thumb = pil_image.resize(new_size, Image.LANCZOS)
                         
                         # サムネイルを表示
-                        st.image(thumb, caption=f"#{i+1}", use_column_width=False)
+                        st.image(thumb, caption=f"#{i+1}", use_container_width=False)
                         
                         # 選択ボタン
                         if st.button(f"表示", key=f"thumb_{i}"):

--- a/hairstyle_analyzer/ui/streamlit_app.py
+++ b/hairstyle_analyzer/ui/streamlit_app.py
@@ -597,7 +597,7 @@ def render_main_content():
         cols = st.columns(min(3, len(uploaded_files)))
         for i, uploaded_file in enumerate(uploaded_files[:6]):  # 最大6枚まで表示
             with cols[i % 3]:
-                st.image(uploaded_file, caption=uploaded_file.name, use_column_width=True)
+                st.image(uploaded_file, caption=uploaded_file.name, use_container_width=True)
         
         # 6枚以上の場合は省略メッセージを表示
         if len(uploaded_files) > 6:


### PR DESCRIPTION
## 変更内容

Streamlitアプリで表示されていた非推奨パラメータの警告メッセージを解消するため、以下の変更を行いました：

### 修正箇所
1. `hairstyle_analyzer/ui/components/image_preview.py`：
   - 4箇所の `use_column_width` パラメータを `use_container_width` に変更
   - 画像表示、サムネイル表示のすべての箇所を修正

2. `hairstyle_analyzer/ui/streamlit_app.py`：
   - アップロードされた画像のプレビュー表示部分の `use_column_width` を `use_container_width` に変更

### 効果
これらの変更により、アプリ実行時に表示されていた以下の非推奨パラメータの警告メッセージが表示されなくなります：

```
The use_column_width parameter has been deprecated and will be removed in a future release. Please utilize the use_container_width parameter instead.
```

Streamlitの最新バージョンの推奨事項に従った実装になり、将来のバージョンでも問題なく動作するようになりました。