### PR TITLE
キャッシュ機能をデフォルトでオフに設定

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -134,7 +134,7 @@ gemini:
     max_templates: 50            # 一度に処理する最大テンプレート数
     use_category_filter: true    # カテゴリでフィルタリングするかどうか
     fallback_on_failure: true    # 失敗時に従来のスコアリングを使用するかどうか
-    cache_results: true          # 結果をキャッシュするかどうか
+    cache_results: false         # 結果をキャッシュするかどうか
     timeout_seconds: 30          # APIタイムアウト（秒）
 
 # スクレイパー設定

--- a/hairstyle_analyzer/services/gemini/gemini_service.py
+++ b/hairstyle_analyzer/services/gemini/gemini_service.py
@@ -12,7 +12,7 @@ import base64
 import logging
 import asyncio
 from pathlib import Path
-from typing import Dict, List, Optional, Any, Union, Tuple
+from typing import Dict, List, Optional, Any, Union, Tuple, AsyncGenerator
 import re
 import random
 
@@ -25,6 +25,8 @@ from ...utils.errors import GeminiAPIError, ValidationError as AppValidationErro
 from ...utils.image_utils import encode_image, is_valid_image
 from ...utils.async_context import AsyncResource, asynccontextmanager, Timer
 
+# 必要なエラー定義をインポート
+from hairstyle_analyzer.utils.errors import ImageError
 
 class APISession(AsyncResource):
     """
@@ -260,7 +262,7 @@ class GeminiService:
         prompt: str, 
         image_path: Optional[Path] = None, 
         use_fallback: bool = False
-    ) -> AsyncResource:
+    ) -> AsyncGenerator[AsyncResource, None]:
         """
         Gemini API呼び出し用の非同期コンテキストマネージャー
         

--- a/hairstyle_analyzer/ui/streamlit_app.py
+++ b/hairstyle_analyzer/ui/streamlit_app.py
@@ -82,7 +82,7 @@ def init_session_state():
     if SESSION_COUPONS not in st.session_state:
         st.session_state[SESSION_COUPONS] = []
     if SESSION_USE_CACHE not in st.session_state:
-        st.session_state[SESSION_USE_CACHE] = True
+        st.session_state[SESSION_USE_CACHE] = False
     # APIキーのセッション変数初期化は削除
     if SESSION_SALON_URL not in st.session_state:
         st.session_state[SESSION_SALON_URL] = ""
@@ -103,7 +103,7 @@ def update_progress(current, total, message=""):
         st.session_state[SESSION_PROGRESS] = progress
 
 
-async def process_images(processor, image_paths, stylists=None, coupons=None, use_cache=True):
+async def process_images(processor, image_paths, stylists=None, coupons=None, use_cache=False):
     """画像を処理して結果を取得する非同期関数"""
     results = []
     total = len(image_paths)


### PR DESCRIPTION
## 変更内容
- GUIにおいて、キャッシュ機能をデフォルトでオフに設定
- 以下の変更を行いました：
  1. streamlit_app.pyのinit_session_state関数内でSESSION_USE_CACHEのデフォルト値をFalseに変更
  2. process_images関数のuse_cacheパラメータのデフォルト値をFalseに変更
  3. config.yamlのtemplate_matching設定内のcache_resultsをfalseに変更

## 影響範囲
- アプリケーション起動時にキャッシュ機能が自動的にオフになります
- ユーザーはUIからいつでもキャッシュ機能をオンに切り替えることができます

## テスト
- アプリケーションを起動し、ログからキャッシュ設定がFalseになっていることを確認しました