### PR TITLE
パスワード認証機能の追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,10 @@ cache/
 output/
 temp/
 
+# Streamlit
+.streamlit/
+.streamlit/secrets.toml
+
 # Jupyter Notebook
 .ipynb_checkpoints
 


### PR DESCRIPTION
## 概要
StreamlitCloudでのアプリ保護のために、パスワード認証機能を追加しました。

## 変更内容
- パスワード認証機能の実装
- `.gitignore`の更新（`.streamlit`ディレクトリを無視）
- ローカル開発時にはパスワード認証をスキップする機能

## テスト方法
1. ローカル環境：`LOCAL_DEV=true`環境変数を設定すると認証をスキップ
2. 本番環境：StreamlitCloudのSecretsに`password`を設定

## 注意点
- `.streamlit/secrets.toml`ファイルはGitにコミットされないため、StreamlitCloudの設定画面で手動設定が必要